### PR TITLE
Feat: 웹소켓 전용 토큰 발급 및 검증 추가

### DIFF
--- a/src/api/interview.js
+++ b/src/api/interview.js
@@ -122,3 +122,18 @@ export async function uploadVideoApi(videoBlob, interviewID, questionID) {
         throw new Error(`서버 오류: ${error.response?.status || error.message}`);
     }
 }
+
+/**
+ * 웹소켓 연결 전, access 토큰으로 웹소켓 인증 전용 토큰을 발급받는 함수
+ * @returns {Promise<string>} 웹소켓 연결에 사용할 짧은 토큰 (socket token)
+ */
+export const getWebsocketToken = async () => {
+  try{
+      const response = await fastapiApi.get(`users/socket-token`);
+      console.log(response.data)
+
+      return response.data.result
+  } catch (error) {
+  throw new Error(`HTTP error! status: ${error.response?.status || error.message}`);
+  }
+}

--- a/src/hooks/useInterviewWebSocket.js
+++ b/src/hooks/useInterviewWebSocket.js
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { convertWebmToWav } from "../utils/toWav";
 import { LASTMENT } from "../data/interview";
-import { reqQuestions } from "../api/interview"; // 이 부분도 상대경로 맞게 조정
+import { reqQuestions, getWebsocketToken } from "../api/interview"; // 이 부분도 상대경로 맞게 조정
 
 export function useInterviewWebSocket({ interviewId, onReceiveQuestion, onComplete }) {
   const websocket = useRef(null);
@@ -24,8 +24,11 @@ export function useInterviewWebSocket({ interviewId, onReceiveQuestion, onComple
         console.log("질문생성: ",data)
         setIsInitialized(true);
 
+        // 웹소켓 전용 인증 토큰 발급
+        const socketToken = await getWebsocketToken()
+
         // 🔌 WebSocket 연결
-        websocket.current = new WebSocket(`${process.env.REACT_APP_WS_URL}interview/${interviewId}`);
+        websocket.current = new WebSocket(`${process.env.REACT_APP_WS_URL}interview/${interviewId}?socket_token=${socketToken}`);
 
         websocket.current.onopen = () => {
           console.log('WebSocket 연결 열림');


### PR DESCRIPTION
- api/interview.js: 웹소켓 전용 토큰 발급 코드 추가
- hooks/useInterviewWebSocket.js : 토큰 발급, 인증 코드 추가
- 동작 과정
1. 웹소켓 시작 전 access 토큰을 이용해 토큰을 발급 
2. 발급한 토큰을 웹소켓 연결 할 때 쿼리스트링으로 전달
3. 연결되면 토큰 유효한지 확인 후 면접 진행